### PR TITLE
Prevent certain posts from being made public

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ DB_USER=dbuser DB_PASSWORD=pass DB_DB=htmlhouse PRIVATE_KEY=keys/dev PUBLIC_KEY=
 | `STATIC_DIR` | Relative dir where static files are stored | `static` |
 | `AUTO_APPROVE` | Automatically approves public posts | false |
 | `PREVIEWS_HOST` | Fully-qualified URL (without trailing slash) of screenshot server | None. |
+| `ADMIN_PASS` | Password to perform admin functions via API | `uhoh` |
+| `BROWSE_ITEMS` | Number of items to show on Browse page | 10 |
 | `TWITTER_KEY` | Twitter consumer key | `notreal` |
 | `TWITTER_SECRET` | Twitter consumer secret | `notreal` |
 | `TWITTER_TOKEN` | Twitter access token of the posting Twitter account | `notreal` |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ DB_USER=dbuser DB_PASSWORD=pass DB_DB=htmlhouse PRIVATE_KEY=keys/dev PUBLIC_KEY=
 | `PREVIEWS_HOST` | Fully-qualified URL (without trailing slash) of screenshot server | None. |
 | `ADMIN_PASS` | Password to perform admin functions via API | `uhoh` |
 | `BROWSE_ITEMS` | Number of items to show on Browse page | 10 |
+| `BLACKLIST_TERMS` | Comma-separated list of terms to prevent a post from being made public | None. |
 | `TWITTER_KEY` | Twitter consumer key | `notreal` |
 | `TWITTER_SECRET` | Twitter consumer secret | `notreal` |
 | `TWITTER_TOKEN` | Twitter access token of the posting Twitter account | `notreal` |

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package htmlhouse
 
 import (
 	"github.com/danryan/env"
+	"regexp"
+	"strings"
 )
 
 type config struct {
@@ -23,6 +25,9 @@ type config struct {
 	AdminPass    string `env:"key=ADMIN_PASS default=uhoh"`
 	BrowseItems  int    `env:"key=BROWSE_ITEMS default=10"`
 
+	BlacklistTerms string `env:"key=BLACKLIST_TERMS"`
+	BlacklistReg   *regexp.Regexp
+
 	// Twitter configuration
 	TwitterConsumerKey    string `env:"key=TWITTER_KEY default=notreal"`
 	TwitterConsumerSecret string `env:"key=TWITTER_SECRET default=notreal"`
@@ -36,5 +41,11 @@ func newConfig() (*config, error) {
 		return cfg, err
 	}
 
+	// Process anything
+	termsReg := `(?i)\b` + cfg.BlacklistTerms + `\b`
+	termsReg = strings.Replace(termsReg, ",", `\b|\b`, -1)
+	cfg.BlacklistReg = regexp.MustCompile(termsReg)
+
+	// Return result
 	return cfg, nil
 }

--- a/construction.go
+++ b/construction.go
@@ -39,7 +39,7 @@ func createHouse(app *app, w http.ResponseWriter, r *http.Request) error {
 
 	resUser := newSessionInfo(houseID)
 
-	if public {
+	if public && passesPublicFilter(app, html) {
 		go addPublicAccess(app, houseID, html)
 	}
 

--- a/construction.go
+++ b/construction.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -90,6 +91,10 @@ func addPublicAccess(app *app, houseID, html string) error {
 	data.Set("url", fmt.Sprintf("%s/%s.html", app.cfg.HostName, houseID))
 
 	u, err := url.ParseRequestURI(app.cfg.PreviewsHost)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing request URI: %v\n", err)
+		return err
+	}
 	u.Path = "/"
 	urlStr := fmt.Sprintf("%v", u)
 

--- a/filter.go
+++ b/filter.go
@@ -1,6 +1,10 @@
 package htmlhouse
 
 func passesPublicFilter(app *app, html string) bool {
+	if app.cfg.BlacklistTerms == "" {
+		return true
+	}
+
 	spam := app.cfg.BlacklistReg.MatchString(html)
 	return !spam
 }

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,6 @@
+package htmlhouse
+
+func passesPublicFilter(app *app, html string) bool {
+	spam := app.cfg.BlacklistReg.MatchString(html)
+	return !spam
+}

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -125,7 +125,7 @@
 			data: {html: editor.getSession().getValue(), public: $publicCheck.checked ? "true" : ""},
 			success: function(data, status, xhr) {
 				publishing = false;
-				{{if .ID}}if (data.meta.code == 200) { {{else}}if (data.meta.code == 201) {
+				{{if .ID}}if (data.code == 200) { {{else}}if (data.code == 201) {
 					var houses = JSON.parse(H.get('neighborhood', '[]'));
 					houses.push({id: data.data.id, token: xhr.getResponseHeader('Authorization')});
 					H.set('neighborhood', JSON.stringify(houses));{{end}}
@@ -133,7 +133,7 @@
 					{{if .ID}}{{else}}H.remove('constructionSite');{{end}}
 					window.location = '/' + data.data.id + '.html';
 				} else {
-					alert(data.meta.error_msg);
+					alert(data.error_msg);
 				}
 			},
 			error: function(jqXHR, status, error) {


### PR DESCRIPTION
This adds a `BLACKLIST_TERMS` configuration value that new public posts will be tested against; if a post contains any of the terms, it will still be published but not made public on the Browse page and tweeted out.

This also fixes some issues caused by updated libraries.